### PR TITLE
fix: cannot select when the window is suddenly focused out

### DIFF
--- a/src/lib/mangadex/componnents/selecto/ChapterFeedSelecto.svelte
+++ b/src/lib/mangadex/componnents/selecto/ChapterFeedSelecto.svelte
@@ -133,4 +133,7 @@
 			canSelect = false;
 		}
 	}}
+	onfocusout={(e) => {
+		canSelect = false;
+	}}
 />


### PR DESCRIPTION
This fix a windows bug where the selecto feature is still active if you switch between desktops.