### PR TITLE
fix: Add 'core:window:allow-is-focused' capability

### DIFF
--- a/src-tauri/core/capabilities/mains.json
+++ b/src-tauri/core/capabilities/mains.json
@@ -34,6 +34,7 @@
 		"opener:allow-reveal-item-in-dir",
 		"notification:allow-notify",
 		"notification:allow-is-permission-granted",
-		"notification:deny-request-permission"
+		"notification:deny-request-permission",
+		"core:window:allow-is-focused"
 	]
 }


### PR DESCRIPTION
Apparently, we need to add capability for ".isFocused()" to work.