### PR TITLE
Fix: Optimize release-fast-compile settings in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,5 +137,5 @@ codegen-units = 1
 # this is used for github test build ci
 [profile.release-fast-compile]
 inherits = "release"
-codegen-units = 256
-incremental = true
+codegen-units = 16
+opt-level = "z"


### PR DESCRIPTION
Reduce codegen units and set optimization level for faster release builds.