### PR TITLE
fix: notification not working properly again (on windows and macos)

### DIFF
--- a/crates/special-eureka-notification/src/other.rs
+++ b/crates/special-eureka-notification/src/other.rs
@@ -32,16 +32,16 @@ impl From<crate::Urgency> for notify_rust::Urgency {
 
 pub fn notify<R: Runtime>(_app: &AppHandle<R>, notification: CrateNotification) {
     let mut notif: Notification = notification.into();
-	// Ref: https://github.com/tauri-apps/plugins-workspace/blob/1bb7beb3076a8bf76b084223d0e4225bb2e53bc9/plugins/notification/src/desktop.rs#L195
-	#[cfg(windows)]
+    // Ref: https://github.com/tauri-apps/plugins-workspace/blob/1bb7beb3076a8bf76b084223d0e4225bb2e53bc9/plugins/notification/src/desktop.rs#L195
+    #[cfg(windows)]
     {
-    	let exe = match tauri::utils::platform::current_exe() {
-    		Ok(exe) => exe,
-    		Err(err) => {
-    			log::warn!();
-    			return;
-    		}	
-    	};
+        let exe = match tauri::utils::platform::current_exe() {
+            Ok(exe) => exe,
+            Err(err) => {
+                log::warn!();
+                return;
+            }
+        };
         let exe_dir = exe.parent().expect("failed to get exe directory");
         let curr_dir = exe_dir.display().to_string();
         // set the notification's System.AppUserModel.ID only when running the installed app
@@ -53,10 +53,10 @@ pub fn notify<R: Runtime>(_app: &AppHandle<R>, notification: CrateNotification) 
     }
     #[cfg(target_os = "macos")]
     {
-    	let _ = notify_rust::set_application(if tauri::is_dev() {
-        	"com.apple.Terminal"
-    	} else {
-        	&_app.config().identifier
+        let _ = notify_rust::set_application(if tauri::is_dev() {
+            "com.apple.Terminal"
+        } else {
+            &_app.config().identifier
         });
     }
 

--- a/crates/special-eureka-notification/src/other.rs
+++ b/crates/special-eureka-notification/src/other.rs
@@ -1,6 +1,8 @@
 use crate::Notification as CrateNotification;
 use notify_rust::Notification;
 use tauri::{AppHandle, Runtime};
+#[cfg(windows)]
+use std::path::MAIN_SEPARATOR as SEP;
 
 impl From<CrateNotification> for Notification {
     fn from(value: CrateNotification) -> Self {

--- a/crates/special-eureka-notification/src/other.rs
+++ b/crates/special-eureka-notification/src/other.rs
@@ -38,7 +38,7 @@ pub fn notify<R: Runtime>(_app: &AppHandle<R>, notification: CrateNotification) 
         let exe = match tauri::utils::platform::current_exe() {
             Ok(exe) => exe,
             Err(err) => {
-                log::warn!();
+                log::warn!("Cannot get current exe {err}");
                 return;
             }
         };

--- a/crates/special-eureka-notification/src/other.rs
+++ b/crates/special-eureka-notification/src/other.rs
@@ -1,8 +1,8 @@
 use crate::Notification as CrateNotification;
 use notify_rust::Notification;
-use tauri::{AppHandle, Runtime};
 #[cfg(windows)]
 use std::path::MAIN_SEPARATOR as SEP;
+use tauri::{AppHandle, Runtime};
 
 impl From<CrateNotification> for Notification {
     fn from(value: CrateNotification) -> Self {

--- a/crates/special-eureka-notification/src/other.rs
+++ b/crates/special-eureka-notification/src/other.rs
@@ -32,7 +32,34 @@ impl From<crate::Urgency> for notify_rust::Urgency {
 
 pub fn notify<R: Runtime>(_app: &AppHandle<R>, notification: CrateNotification) {
     let mut notif: Notification = notification.into();
-    notif.auto_icon();
+	// Ref: https://github.com/tauri-apps/plugins-workspace/blob/1bb7beb3076a8bf76b084223d0e4225bb2e53bc9/plugins/notification/src/desktop.rs#L195
+	#[cfg(windows)]
+    {
+    	let exe = match tauri::utils::platform::current_exe() {
+    		Ok(exe) => exe,
+    		Err(err) => {
+    			log::warn!();
+    			return;
+    		}	
+    	};
+        let exe_dir = exe.parent().expect("failed to get exe directory");
+        let curr_dir = exe_dir.display().to_string();
+        // set the notification's System.AppUserModel.ID only when running the installed app
+        if !(curr_dir.ends_with(format!("{SEP}target{SEP}debug").as_str())
+            || curr_dir.ends_with(format!("{SEP}target{SEP}release").as_str()))
+        {
+            notif.app_id(&_app.config().identifier);
+        }
+    }
+    #[cfg(target_os = "macos")]
+    {
+    	let _ = notify_rust::set_application(if tauri::is_dev() {
+        	"com.apple.Terminal"
+    	} else {
+        	&_app.config().identifier
+        });
+    }
+
     if let Err(err) = notif.show() {
         log::error!("{err}");
     }


### PR DESCRIPTION
The notification doesn't work properly on windows,
It shows powershell instead of the special eureka.

The fix is a copy-paste of https://github.com/tauri-apps/plugins-workspace/blob/1bb7beb3076a8bf76b084223d0e4225bb2e53bc9/plugins/notification/src/desktop.rs#L195

_Also, i am using my work account since my personal computer where my main account is at is broken._