### PR TITLE
chore: `release-fast-compile-no-bundle` for forks

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -74,6 +74,13 @@ jobs:
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_PASSWORD }}
+        if: ${{ env.TAURI_SIGNING_PRIVATE_KEY != '' && env.TAURI_SIGNING_PRIVATE_KEY_PASSWORD != '' }}
+      - name: build it the app (no-bundle)
+        run: cargo make release-fast-compile-no-bundle
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_PASSWORD }}
+        if: ${{ env.TAURI_SIGNING_PRIVATE_KEY == '' && env.TAURI_SIGNING_PRIVATE_KEY_PASSWORD == '' }}
           # moved back to the make file file
           # CARGO_BUILD_PROFILE: release-fast-compile
       # TODO add reports to the actual pr about the bundle sizes

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -69,3 +69,8 @@ workspace = false
 command = "pnpm"
 args = ["build", "--", "--profile", "release-fast-compile"]
 env = { "CARGO_BUILD_PROFILE" = "release-fast-compile" }
+
+[tasks.release-fast-compile-no-bundle]
+workspace = false
+command = "pnpm"
+args = ["build", "--no-bundle", "--", "--profile", "release-fast-compile"]


### PR DESCRIPTION
This pr will allow `test-build` jobs to run successfully on fork pr by using `--no-bundle` 
if the tauri private key/password is not set in the fork secret registry.